### PR TITLE
NULL EXCLUSION , Optimized relationship creations/node mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ config = {
                
               {'node_group_name': 'a2', 'label': 'Place', 'row_level_node_keys': ['County'], 
                'one_to_many': [
-                              {"attribute_name":"officials", "column_name":"leader_name", sub_columns:[ {"column_name":"leader_child_name"}] }
+                              {"attribute_name":"officials", "column_name":"leader_name", "sub_columns":[ {"column_name":"leader_child_name"}] }
                ], 
                'derived': [
                    {'attribute_name': 'employees_vaccinated', 'operation': 'SUM', 'columns': ['Emp_Number_Vaccinated']},
@@ -102,7 +102,7 @@ config = {
 
 * **Node Group Name** - *The user-defined name of the node group to identify in the relationship block*
 * **Label** - *A class based descriptor for this type of node... ie: Person, Place*
-* **Row Level Node Keys** - *The rows that uniquely identify this node in the dataframe*
+* **Row Level Node Keys** - *The rows that uniquely identify this node in the dataframe. Much like a database key, these must never be null. It is recommended that if you have a field that may be null, you can use the `"DISTINCT"` type in the `Derived` section*
 * **One To Many** - *How to bring in data that has multiple values per Row Level Node Keys. More on this below*
 * **Derived** - *Summary/Derived information at the node level, support operations listed below*
 
@@ -137,7 +137,7 @@ Derived calculates data to store as an attribute & works in the following way:
       lowest_score        MIN       ['grade']
       unique_people      COUNTD     ['customer_id','salesman_id']
       num_of_visits      COUNT      ['person_id']
-      unique_states     DISTINCT    ['state_abbreviation']
+      unique_states     DISTINCT    ['state_abbreviation']      
                     
      
     You can think of these as hamburger stacking multiple columns and deriving information.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 ### How to get started
 
+
+
+
+### FOR CURRENT DEVELOPMENT ONLY:
+
+*Pull this repository down, use the `test.py` and `manual_test.py` files to pass data through. One is built for reading csv's and the other is a manually created ```python list[dict]```*  
+```shell
+git clone https://github.com/axrati/pykeral.git
+```
+
+
+### FUTURE STATE
+
+
 *Install the library in the dist/ folder*  
 ```shell
 pip install pykeral.whl

--- a/README.md
+++ b/README.md
@@ -63,36 +63,36 @@ dfx.queries
 *This is the basic syntax for identifying nodes/relationships. Beneath the codeblock is a description of each key*  
 ```json
 config = {
-    'nodes': 
+    "nodes": 
           [
           
-              {'node_group_name': 'a1', 'label': 'Place', 'row_level_node_keys': ['State'], 
-               'one_to_many': [
+              {"node_group_name": "a1", "label": "Place", "row_level_node_keys": ["State"], 
+               "one_to_many": [
                                {  "attribute_name":"officials", "column_name":"leader_name" }
                ], 
-               'derived': [
-                   {'attribute_name': 'employees_vaccinated', 'operation': 'SUM', 'columns': ['Emp_Number_Vaccinated']},
-                   {'attribute_name': 'employees_working', 'operation': 'SUM', 'columns': ['Emp_Number_Working']}
+               "derived": [
+                   {"attribute_name": "employees_vaccinated", "operation": "SUM", "columns": ["Emp_Number_Vaccinated"]},
+                   {"attribute_name": "employees_working", "operation": "SUM", "columns": ["Emp_Number_Working"]}
                    ]
                },
                
-              {'node_group_name': 'a2', 'label': 'Place', 'row_level_node_keys': ['County'], 
-               'one_to_many': [
+              {"node_group_name": "a2", "label": "Place", "row_level_node_keys": ["County"], 
+               "one_to_many": [
                               {"attribute_name":"officials", "column_name":"leader_name", "sub_columns":[ {"column_name":"leader_child_name"}] }
                ], 
-               'derived': [
-                   {'attribute_name': 'employees_vaccinated', 'operation': 'SUM', 'columns': ['Emp_Number_Vaccinated']},
-                   {'attribute_name': 'employees_working', 'operation': 'SUM', 'columns': ['Emp_Number_Working']}
+               "derived": [
+                   {"attribute_name": "employees_vaccinated", "operation": "SUM", "columns": ["Emp_Number_Vaccinated"]},
+                   {"attribute_name": "employees_working", "operation": "SUM", "columns": ["Emp_Number_Working"]}
                    ]
                }
                
           ], 
-     'relationships': 
+     "relationships": 
               [
-                  {'rel_group_name': 'rel_type_1',  'name': 'HAS_SUBREGION',  'row_attributes': ['Mask Required'], 
-                  'label': 'geographic', 'from': 'a1', 'to': 'a2', 
-                   'derived': [
-                       {'attribute_name': 'hospital_count', 'operation': 'SUM', 'columns': ['Number of Hospitals']}
+                  {"rel_group_name": "rel_type_1",  "name": "HAS_SUBREGION",  "row_attributes": ["Mask Required"], 
+                  "label": "geographic", "from": "a1", "to": "a2", 
+                   "derived": [
+                       {"attribute_name": "hospital_count", "operation": "SUM", "columns": ["Number of Hospitals"]}
                        ]
                    }
                       ]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ dfx.queries
 ### Config
 
 *This is the basic syntax for identifying nodes/relationships. Beneath the codeblock is a description of each key*  
-```json
+```python
 config = {
     "nodes": 
           [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### FOR CURRENT DEVELOPMENT ONLY:
 
-*Pull this repository down, use the `test.py` and `manual_test.py` files to pass data through. One is built for reading csv's and the other is a manually created ```python list[dict]```*  
+*Pull this repository down, use the `test.py` and `manual_test.py` files to pass data through. One is built for reading csv's and the other is a manually created ```list[dict]```*  
 ```shell
 git clone https://github.com/axrati/pykeral.git
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dfx = dfxc(df)
 
 <br>
 
-*To generate nodes/relationships on your dfx object, fish with a config object (see below example)*  
+*To generate nodes/relationships on your dfx object, fish with a config dict (see below example)*  
 ```python
 dfx.fish(config)
 ```
@@ -61,8 +61,8 @@ dfx.queries
 ### Config
 
 *This is the basic syntax for identifying nodes/relationships. Beneath the codeblock is a description of each key*  
-```python
-config = {
+```json
+{
     "nodes": 
           [
           

--- a/README.md
+++ b/README.md
@@ -7,17 +7,19 @@
 ### How to get started
 
 *Install the library in the dist/ folder*  
-```
+```shell
 pip install pykeral.whl
 ```
 
-*Import dfxc from the main library*  
-```
+*Import dfxc and pandas from the main libraries*  
+```python
 from pykeral.main import dfxc
+import pandas as pd
 ```
 
 *Apply to a dataframe*  
-```
+```python
+df = pd.Dataframe() # Your data goes here
 dfx = dfxc(df)
 ```
 <br>
@@ -27,12 +29,12 @@ dfx = dfxc(df)
 <br>
 
 *To generate nodes/relationships on your dfx object, fish with a config object (see below example)*  
-```
+```python
 dfx.fish(config)
 ```
 
 *Access the data*  
-```
+```python
 dfx.nodes
 dfx.relationships
 
@@ -41,12 +43,12 @@ dfx.relationships[0].help()
 ```
 
 *Generate queries (only Cypher today)*  
-```
+```python
 dfx.query("cypher")
 ```
 
 *Access Queries*  
-```
+```python
 dfx.queries
 ```
 
@@ -59,7 +61,7 @@ dfx.queries
 ### Config
 
 *This is the basic syntax for identifying nodes/relationships. Beneath the codeblock is a description of each key*  
-```
+```json
 config = {
     'nodes': 
           [

--- a/lib/dataframe_factory/derived.py
+++ b/lib/dataframe_factory/derived.py
@@ -45,6 +45,7 @@ def derived_handler(derived_obj, dataframe):
 
     elif sent_option == "DISTINCT":
         data = stack_cols(sent_columns,dataframe)
+        data = data.dropna()
         return {return_key:list(data['summarizer'].unique())}
     
     else:

--- a/lib/dataframe_factory/df_utils.py
+++ b/lib/dataframe_factory/df_utils.py
@@ -1,9 +1,14 @@
+import pandas as pd
+
 def row_to_dict(dataframe,columns):
     decon_arr = []
     for index, row in dataframe.iterrows():
         data = {}
         for i in columns:
-            data[str(i)]=row[i]
+            if pd.isna(row[i]):
+                data[str(i)]=None
+            else:
+                data[str(i)]=row[i]
         decon_arr.append(data)
     return decon_arr
 
@@ -23,16 +28,44 @@ def get_node(rel_name, nodes):
 def rel_query_gen(node_o_keys, node_o_data, node_t_keys, node_t_data):
     where = ''
     for key in node_o_keys:
-        if type(node_o_data[key])==str:
+        if node_o_data[key] is None:
+            where += "{}.isnull() & ".format(key)
+        elif type(node_o_data[key])==str:
             where += "{}=='{}' & ".format(key,node_o_data[key])
         else:
             where += "{}=={} & ".format(key,node_o_data[key])
 
     for key in node_t_keys:
-        if type(node_t_data[key])==str:
+        if node_t_data[key] is None:
+            where += "{}.isnull() & ".format(key)
+        elif type(node_t_data[key])==str:
             where += "{}=='{}' & ".format(key,node_t_data[key])
         else:
             where += "{}=={} & ".format(key,node_t_data[key])
     where_q = where[0:len(where)-2]
     return where_q
 
+
+def keys_of_group_name(node_group_name,node_schema):
+    check = 0
+    for node_frame in node_schema:
+        if node_frame['node_group_name']==node_group_name:
+            check+=1
+            return node_frame['row_level_node_keys']
+    if check == 0:
+        raise Exception("You searched for a node group name that doesnt exist in the supplied node schema... {}".format(node_group_name))
+
+
+def multi_cond_query(col_names:list,vals:list):
+    if len(col_names)!=len(vals):
+        raise Exception("You tried to create a df query with unequalivalent lengths of column array to value array... \n{}\n{}".format(str(col_names),str(vals)))
+    where = ''
+    for key in range(len(col_names)):
+        if vals[key] is None:
+            where += "{}.isnull() & ".format(col_names[key])
+        elif type(vals[key])==str:
+            where += "{}=='{}' & ".format(col_names[key],vals[key])
+        else:
+            where += "{}=={} & ".format(col_names[key],vals[key])
+    where_q = where[0:len(where)-2]
+    return where_q

--- a/lib/dataframe_factory/engine.py
+++ b/lib/dataframe_factory/engine.py
@@ -2,7 +2,7 @@ import pandas as pd
 from lib.utils.tools import all_exist_in
 from lib.dataframe_factory.node_linter import node_df_config_linter
 from lib.dataframe_factory.relationship_linter import relationship_df_config_linter
-from lib.dataframe_factory.df_utils import row_to_dict, get_node, rel_query_gen
+from lib.dataframe_factory.df_utils import row_to_dict, get_node, rel_query_gen, keys_of_group_name, multi_cond_query
 from lib.object_factory.node_factory import Node
 from lib.object_factory.relationship_factory import Relationship
 from lib.dataframe_factory.derived import derived_handler
@@ -12,7 +12,9 @@ def node_df_execution(dataframe, schema):
 
     nodes = []
     relationships = []
-
+    node_id_map = {}
+    # Access map for df of key/vals and node_id under `pykeral_id`
+    node_gn_map = {}
 
 
 
@@ -32,7 +34,21 @@ def node_df_execution(dataframe, schema):
         node_group_name=node['node_group_name']
     
         pd_cols = node['row_level_node_keys']
+        # Should count be here as a means of "checkout"?
         unique_combinations = dataframe.groupby(pd_cols).size().reset_index().rename(columns={0:'count'})
+        # Perhaps shift this up and use it while looping through relationships !!!!!!!
+        # Much less data to sift through - potentially sub query df faster
+        # Answer is to get distinct keys of each node, filter the dataframe on only those columns, do a distinct.
+        # --- For each key group, determine which nodes have the same triplet of info
+        # I think this info is avilalbe via node['keys'] and the entrance of those keys: node['node['keys'][x]]
+
+        # Is the better solution to add a node_id column to the dataframe?
+        # IE - loop through and add where={fomr-key_1}&&{from-key-2}&&{to-key-1}&&{to-key-2}
+        # Function for this is rel_query_gen
+
+        # Broad then deep search on keys... staged ifs
+
+        # This matches index of unique_combos
         node_dicts = row_to_dict(unique_combinations,pd_cols)
 
 
@@ -40,12 +56,16 @@ def node_df_execution(dataframe, schema):
         for node_row in node_dicts:
             # Get df data
             node_sub_data = dataframe.query(otm_query(node_row))
+            # Should this get attached?^^^^
     
             ## Handle one_to_many first
             processed_otm=[]
             for otm in node['one_to_many']:
                 attr_name = otm['attribute_name']
+                # if type()
                 level_cols_in_order = [otm['column_name']]
+                # If you wanted to supply multiple columns for a otm
+                # level_cols_in_order = otm['column_name']
                 col_sub_maps = []
                 otm_trav(otm, col_sub_maps, level_cols_in_order)
                 otm_sub_data = node_sub_data[level_cols_in_order]
@@ -56,7 +76,7 @@ def node_df_execution(dataframe, schema):
                     d_vals = list(otm_sub_data[otm['column_name']].unique())
                     generics[attr_name]=d_vals
                     itemization.append(generics)
-                    
+
                 for mapping in col_sub_maps:
                     generics = {}
                     generics[attr_name]={}
@@ -78,13 +98,28 @@ def node_df_execution(dataframe, schema):
             for derv in node['derived']:
                 derv_final = derived_handler(derv,node_sub_data)
                 processed_derv.append(derv_final)
+
             node_row['derived']=processed_derv
 
+        gn_map_frames=[]
         for indiv_node in node_dicts:
-            nodes.append(Node(self_name=node_group_name, contents=indiv_node, label=label, keys=pd_cols))
+            # Create Node
+            new_node = Node(self_name=node_group_name, contents=indiv_node, label=label, keys=pd_cols)
+            # Creating mapping dataframe of ID to key/vals
+            raw_node = {}
+            for key in pd_cols:
+                raw_node[key]=indiv_node[key]
+            raw_node["pykeral_id"]=new_node.id
+            raw_node_df = pd.DataFrame([raw_node])
+            gn_map_frames.append(raw_node_df)
 
+            # Add to all node arr
+            nodes.append(new_node)
+            # Add to node by id dict
+            node_id_map[new_node.id]=new_node
 
-
+        total_gn_map = pd.concat(gn_map_frames)
+        node_gn_map[node_group_name]=total_gn_map
 
 
 
@@ -100,46 +135,74 @@ def node_df_execution(dataframe, schema):
         from_nodes = get_node(from_group,nodes)
         to_nodes = get_node(to_group, nodes)
         row_attrs = relationship['row_attributes']
+        from_keys = keys_of_group_name(from_group,schema['nodes'])
+        to_keys = keys_of_group_name(to_group,schema['nodes'])
+        from_ng_map = node_gn_map[from_group]
+        to_ng_map = node_gn_map[to_group]
 
-        for frm in from_nodes:
-            frm_keys = frm.keys
-            frm_data = frm.data
-            frm_id = frm.id
-            for tom in to_nodes:
-                tom_keys = tom.keys
-                tom_data = tom.data
-                tom_id = tom.id
-                sub_query = rel_query_gen(frm_keys, frm_data, tom_keys, tom_data)
-                potential_rel = dataframe.query(sub_query)
 
-                if len(potential_rel)>0:
-                    relationship_frame = {}
-                    all_rel_columns = list(potential_rel.columns)
-                    if len(row_attrs)>0:
-                        for attr in row_attrs:
-                            attrs_df_vals = list(potential_rel[attr].unique())
-                            if len(attrs_df_vals)==1:
-                                relationship_frame[attr]=attrs_df_vals[0]
-                            else:
-                                relationship_frame[attr]=attrs_df_vals
-                    schema_data = row_to_dict(potential_rel,all_rel_columns)
-                    relationship_frame['name']=relationship['name']
-                    relationship_frame['rel_group_name']=rel_group_name
-                    from_to_nodes={"from":frm_id, "to":tom_id}
-                    # Get Derived
-                    relationship_derived = []
-                    for derv in relationship['derived']:
-                        derv_final = derived_handler(derv,potential_rel)
-                        relationship_derived.append(derv_final)
-                    relationship_frame['derived']=relationship_derived
-                    relationship_frame['schema']=schema_data
-                    final_rel = Relationship(schema=relationship_frame, from_to_nodes=from_to_nodes, label=relationship_label)
-                    relationships.append(final_rel)
-                    # Manage Node Data
-                    rel_id = final_rel.id
-                    node_rel_data = {"from":frm_id, "to":tom_id, "relationship_id":rel_id}
-                    frm.add_rel("from",node_rel_data)
-                    tom.add_rel("to",node_rel_data)
+        # Create combined df between the keys:
+        # f-a, f-b, fc   t-a, t-b
+        # Join in the key data.
+        # IMPORTANT - X will always be first join, Y will always be second.
+        # In this code it'll be from->to
+        mapped_nodes_df = dataframe.merge(from_ng_map,on=from_keys).merge(to_ng_map,on=to_keys)
+        # ^^^ Use this data for all your queries now, as you only want sums and stuff from this
+        pure_id_map = mapped_nodes_df[['pykeral_id_x','pykeral_id_y']]
+        pure_id_map.drop_duplicates(inplace=True)
+        pure_id_map.rename(columns={'pykeral_id_x':"from",'pykeral_id_y':"to"}, inplace=True)
+
+        # Loop through these combinations and apply relationship
+        for idx,row in pure_id_map.iterrows():
+            df_from_id = row['from']
+            df_to_id = row['to']
+            sub_query = multi_cond_query(["pykeral_id_x","pykeral_id_y"],[df_from_id, df_to_id])
+            potential_rel = mapped_nodes_df.query(sub_query)
+
+
+        # for frm in from_nodes:
+        #     frm_keys = frm.keys
+        #     frm_data = frm.data
+        #     frm_id = frm.id
+        #     for tom in to_nodes:
+        #         tom_keys = tom.keys
+        #         tom_data = tom.data
+        #         tom_id = tom.id
+        #         sub_query = rel_query_gen(frm_keys, frm_data, tom_keys, tom_data)
+        #         potential_rel = dataframe.query(sub_query)
+
+
+            ## Theoretically this shoudl also be true, keeping incase of need to revert to legacy above
+            if len(potential_rel)>0:
+                relationship_frame = {}
+                all_rel_columns = list(potential_rel.columns)
+                if len(row_attrs)>0:
+                    for attr in row_attrs:
+                        attrs_df_vals = list(potential_rel[attr].unique())
+                        if len(attrs_df_vals)==1:
+                            relationship_frame[attr]=attrs_df_vals[0]
+                        else:
+                            relationship_frame[attr]=attrs_df_vals
+                schema_data = row_to_dict(potential_rel,all_rel_columns)
+                relationship_frame['name']=relationship['name']
+                relationship_frame['rel_group_name']=rel_group_name
+                from_to_nodes={"from":df_from_id, "to":df_to_id}
+                # Get Derived
+                relationship_derived = []
+                for derv in relationship['derived']:
+                    derv_final = derived_handler(derv,potential_rel)
+                    relationship_derived.append(derv_final)
+                relationship_frame['derived']=relationship_derived
+                relationship_frame['schema']=schema_data
+                final_rel = Relationship(schema=relationship_frame, from_to_nodes=from_to_nodes, label=relationship_label)
+                relationships.append(final_rel)
+                # Manage Node Data
+                rel_id = final_rel.id
+                node_rel_data = {"from":df_from_id, "to":df_to_id, "relationship_id":rel_id}
+                node_id_map[df_from_id].add_rel("from",node_rel_data)
+                node_id_map[df_to_id].add_rel("to",node_rel_data)
+                # frm.add_rel("from",node_rel_data)
+                # tom.add_rel("to",node_rel_data)
 
 
                     

--- a/lib/dataframe_factory/engine.py
+++ b/lib/dataframe_factory/engine.py
@@ -36,17 +36,6 @@ def node_df_execution(dataframe, schema):
         pd_cols = node['row_level_node_keys']
         # Should count be here as a means of "checkout"?
         unique_combinations = dataframe.groupby(pd_cols).size().reset_index().rename(columns={0:'count'})
-        # Perhaps shift this up and use it while looping through relationships !!!!!!!
-        # Much less data to sift through - potentially sub query df faster
-        # Answer is to get distinct keys of each node, filter the dataframe on only those columns, do a distinct.
-        # --- For each key group, determine which nodes have the same triplet of info
-        # I think this info is avilalbe via node['keys'] and the entrance of those keys: node['node['keys'][x]]
-
-        # Is the better solution to add a node_id column to the dataframe?
-        # IE - loop through and add where={fomr-key_1}&&{from-key-2}&&{to-key-1}&&{to-key-2}
-        # Function for this is rel_query_gen
-
-        # Broad then deep search on keys... staged ifs
 
         # This matches index of unique_combos
         node_dicts = row_to_dict(unique_combinations,pd_cols)
@@ -159,19 +148,6 @@ def node_df_execution(dataframe, schema):
             sub_query = multi_cond_query(["pykeral_id_x","pykeral_id_y"],[df_from_id, df_to_id])
             potential_rel = mapped_nodes_df.query(sub_query)
 
-
-        # for frm in from_nodes:
-        #     frm_keys = frm.keys
-        #     frm_data = frm.data
-        #     frm_id = frm.id
-        #     for tom in to_nodes:
-        #         tom_keys = tom.keys
-        #         tom_data = tom.data
-        #         tom_id = tom.id
-        #         sub_query = rel_query_gen(frm_keys, frm_data, tom_keys, tom_data)
-        #         potential_rel = dataframe.query(sub_query)
-
-
             ## Theoretically this shoudl also be true, keeping incase of need to revert to legacy above
             if len(potential_rel)>0:
                 relationship_frame = {}
@@ -201,8 +177,7 @@ def node_df_execution(dataframe, schema):
                 node_rel_data = {"from":df_from_id, "to":df_to_id, "relationship_id":rel_id}
                 node_id_map[df_from_id].add_rel("from",node_rel_data)
                 node_id_map[df_to_id].add_rel("to",node_rel_data)
-                # frm.add_rel("from",node_rel_data)
-                # tom.add_rel("to",node_rel_data)
+
 
 
                     

--- a/lib/dataframe_factory/otm.py
+++ b/lib/dataframe_factory/otm.py
@@ -23,7 +23,9 @@ def otm_levels(level,place):
 def otm_query(node):
     where = ''
     for key in list(node.keys()):
-        if type(node[key])==str:
+        if node[key] is None:
+            where += "{}.isnull() & ".format(key)
+        elif type(node[key])==str:
             where += "{}=='{}' & ".format(key,node[key])
         else:
             where += "{}=={} & ".format(key,node[key])

--- a/lib/object_factory/relationship_factory.py
+++ b/lib/object_factory/relationship_factory.py
@@ -19,7 +19,7 @@ class Relationship:
 Accessible properities:
 
   self.id === Auto-generated id
-  self.data === Dictionary of relationship data
+  self.data === Dictionary of relationship data. At a minumium as keys of "name", "rel_group_name", "derived" and "schema". The other keys are supplied in row_attributes, but isnt required
   self.label === Should really be set
   self.from_to_nodes === From/To Node IDs
 

--- a/lib/utils/tools.py
+++ b/lib/utils/tools.py
@@ -33,6 +33,14 @@ def all_exist_in (arr1, arr2):
     return check==0
 
 
+def list_cleaner(dlist):
+    """
+Remove None's and nan's from lists
+    """
+    new_list = []
+    for i in dlist:
+        print(i)
+    return None
 
 
 
@@ -66,6 +74,10 @@ def q_dtype(key,obj):
         return start+guts
     elif type(val)==bool:
         return '{}:{}, '.format(cypher_key,obj[key])
+    elif obj[key] is None:
+        # Need to understand how to best handle this. Nulls techincally shouldnt exist but its just an attr here
+        return ""
+        # return "{}:'{}', ".format(cypher_key,"NONE")
     else:
         print(key, obj)
         print(type(key), type(obj))

--- a/manual_test.py
+++ b/manual_test.py
@@ -1,0 +1,96 @@
+from pykeral.main import dfxc
+import pandas as pd
+
+#1) Create Data
+raw_data = [
+    {"name":"Alex", "gender":"M", "legal":True, "employer":None, "visit_cost":111, "child":"Joanna", "child_age":18, "hospital":"A"},
+    {"name":"Alex", "gender":"M", "legal":True, "employer":None, "visit_cost":111, "child":"Brick", "child_age":12, "hospital":"A"},
+    {"name":"George", "gender":"M", "legal":False, "employer":"Aetna", "visit_cost":500, "child":"Karen", "child_age":12, "hospital":"A"},
+    # {"name":"Jill", "gender":"F", "legal":True, "employer":"Aetna", "visit_cost":500, "child":None, "child_age":None, "hospital":"A"},
+    {"name":"Margret", "gender":"F", "legal":True, "employer":"Walmart", "visit_cost":2222, "child":"Brick", "child_age":24, "hospital":"B"},
+    {"name":"Carolina", "gender":"F", "legal":False, "employer":"Target", "visit_cost":999, "child":"Brick", "child_age":23, "hospital":"B"},
+    {"name":"Rodrigo", "gender":"M", "legal":False, "employer":None, "visit_cost":1500, "child":"Betty", "child_age":45, "hospital":"B"},
+]
+df = pd.DataFrame(raw_data)
+
+#2) Create dfx
+dfx = dfxc(df)
+
+#3) Generate Schema
+config = {
+    'nodes': 
+          [
+              {'node_group_name': 'a1', 'label': 'Person', 'row_level_node_keys': ['name','gender','legal'], 
+               'one_to_many': [
+                              {"attribute_name":"children", "column_name":"child", "sub_columns":[ {"column_name":"child_age"}] },
+                            # {"attribute_name":"child_age", "column_name":"child_age" }
+               ],  
+               'derived': [
+                   {'attribute_name': 'total_claims', 'operation': 'SUM', 'columns': ['visit_cost']},
+                   {'attribute_name': 'total_visits', 'operation': 'COUNT', 'columns': ['name']}
+                   ]
+               },
+              {'node_group_name': 'a2', 'label': 'Employer', 'row_level_node_keys': ['employer'], 
+               'one_to_many': [], 
+               'derived': [
+                   {'attribute_name': 'total_employees', 'operation': 'COUNTD', 'columns': ['name']},
+                   {'attribute_name': 'total_costs', 'operation': 'SUM', 'columns': ['visit_cost']}
+                   ]
+               },
+            {'node_group_name': 'a3', 'label': 'Hospital', 'row_level_node_keys': ['hospital'], 
+               'one_to_many': [], 
+               'derived': [
+                   {'attribute_name': 'total_visits', 'operation': 'COUNT', 'columns': ['name']},
+                   {'attribute_name': 'total_costs', 'operation': 'SUM', 'columns': ['visit_cost']}
+                   ]
+               }
+          ], 
+     'relationships': 
+              [
+                  {'rel_group_name': 'rel_type_1',  'name': 'HAS_EMPLOYEE',  'row_attributes': [], 
+                  'label': 'employoment', 'from': 'a2', 'to': 'a1', 
+                   'derived': [
+                       {'attribute_name': 'total_cost', 'operation': 'SUM', 'columns': ['visit_cost']}
+                       ]
+                   },
+                {'rel_group_name': 'rel_type_2',  'name': 'VISITED_HOSPITAL',  'row_attributes': [], 
+                  'label': 'employoment', 'from': 'a1', 'to': 'a3', 
+                   'derived': [
+                       {'attribute_name': 'total_cost', 'operation': 'SUM', 'columns': ['visit_cost']},
+                        {'attribute_name': 'total_visits', 'operation': 'COUNT', 'columns': ['name']}
+                       ]
+                   },
+                    ]
+      }
+
+#4) Fish for nodes/rels
+dfx.fish(config)
+
+#5) Generate queries
+dfx.query_generator("cypher")
+
+# #6) Connect to database
+# dfx.connect("Neo4j", { "host":"localhost", "port":7687, "database":"neo4j", "username":"neo4j", "password":"password" } )
+
+#7) Query/Create your data
+for query in dfx.queries['nodes']:
+    # dfx.dbconn.query(query,False)
+    print(query)
+for query in dfx.queries['relationships']:
+    print(query)
+    # dfx.dbconn.query(query,False)
+
+# #8) Validate Data
+# new_data = dfx.dbconn.query("match (n)-[p]-(m) return n,p,m limit 10")
+# print(new_data)
+
+# print(dfx.queries)
+
+
+
+
+
+
+
+
+

--- a/test.py
+++ b/test.py
@@ -44,15 +44,28 @@ dfx.fish(config)
 #5) Generate queries
 dfx.query_generator("cypher")
 
-#6) Connect to database
-dfx.connect("Neo4j", { "host":"localhost", "port":7687, "database":"neo4j", "username":"neo4j", "password":"password" } )
+# #6) Connect to database
+# dfx.connect("Neo4j", { "host":"localhost", "port":7687, "database":"neo4j", "username":"neo4j", "password":"password" } )
 
 #7) Query/Create your data
 for query in dfx.queries['nodes']:
-    dfx.dbconn.query(query,False)
+    # dfx.dbconn.query(query,False)
+    print(query)
 for query in dfx.queries['relationships']:
-    dfx.dbconn.query(query,False)
+    print(query)
+    # dfx.dbconn.query(query,False)
 
-#8) Validate Data
-new_data = dfx.dbconn.query("match (n)-[p]-(m) return n,p,m limit 10")
-print(new_data)
+# #8) Validate Data
+# new_data = dfx.dbconn.query("match (n)-[p]-(m) return n,p,m limit 10")
+# print(new_data)
+
+# print(dfx.queries)
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
I want to note that bringing back NULL on keys can be done when calling this line due to added handling in the `rel_query_gen` query:
```python

 unique_combinations = dataframe.groupby(pd_cols).size().reset_index().rename(columns={0:'count'})

#to

 unique_combinations = dataframe.groupby(pd_cols, dropna=False).size().reset_index().rename(columns={0:'count'})

```

Added NULL exclusion for row-level-keys, optimized (need to test at scale) the node_mapping and rel identification process. Enhanced some docs, added new test file for manually created data. Pushing this and going to look back into the OTM creation